### PR TITLE
fix for gem not found

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,13 +1,11 @@
 steps:
 - id: 'Install gems for Jekyll'
   name: 'gcr.io/$PROJECT_ID/jekyll'
-  args: ['install']
-  dir: 'jekyll'
+  args: ['install', '--path', 'vendor/bundle']
 
 - id: 'Build site into `_site`'
   name: 'gcr.io/$PROJECT_ID/jekyll'
   args: ['exec','jekyll','build']
-  dir: 'jekyll'
 
 - id: 'Push generated site to GCS'
   name: 'gcr.io/cloud-builders/gsutil'

--- a/jekyll-builder/Dockerfile
+++ b/jekyll-builder/Dockerfile
@@ -1,0 +1,7 @@
+FROM gcr.io/cloud-builders/gcloud-slim
+
+RUN apt-get update && apt-get install -y ruby ruby-dev build-essential
+RUN gem install jekyll bundler
+
+# this builder assumes user is using jekyll via ruby bundle
+ENTRYPOINT ["bundle"]

--- a/jekyll-builder/README.md
+++ b/jekyll-builder/README.md
@@ -1,0 +1,7 @@
+# Jekyll Builder
+
+To access this builder in your cloudbuild.yaml, first push to Google Container Registry.
+
+```
+gcloud builds submit --tag gcr.io/$GCLOUD_PROJECT/jekyll
+```


### PR DESCRIPTION
cloudbuild.yaml
* removed jekyll dir because it was not being used in build
* moved gems to vendor/bundle
    - gems were previously not saving in the jekyll dir, so the jekyll gem couldn't be found

jekyll-builder
* moved Dockerfile into dir with directions on how to push to gcr
  